### PR TITLE
Remove unused className prop from EscrowSystem

### DIFF
--- a/frontend/src/components/escrow/EscrowSystem.tsx
+++ b/frontend/src/components/escrow/EscrowSystem.tsx
@@ -34,7 +34,6 @@ interface EscrowSystemProps {
   onCreateEscrow?: (data: CreateEscrowData) => Promise<void>;
   onReleasePayment?: (escrowId: string) => Promise<void>;
   onDispute?: (escrowId: string, reason: string) => Promise<void>;
-  className?: string;
 }
 
 export interface CreateEscrowData {
@@ -78,7 +77,6 @@ export const EscrowSystem = ({
   onCreateEscrow,
   onReleasePayment,
   onDispute,
-  className,
 }: EscrowSystemProps) => {
   const [view, setView] = useState<'overview' | 'create' | 'dispute'>('overview');
   const [createData, setCreateData] = useState<CreateEscrowData>({


### PR DESCRIPTION
The className prop was accepted in the interface and destructured but never applied to any element. Removed it to avoid confusion since no caller passes it.

Closes #61