### PR TITLE
Use network-aware API URL in stacksApi instead of hardcoded mainnet

### DIFF
--- a/frontend/src/utils/stacksApi.ts
+++ b/frontend/src/utils/stacksApi.ts
@@ -19,6 +19,10 @@ function resolveApiUrl(): string {
 
 const STACKS_API_URL = resolveApiUrl();
 
+if (import.meta.env.DEV) {
+    console.log(`[stacksApi] Using ${NETWORK_MODE} API: ${STACKS_API_URL}`);
+}
+
 export interface StacksTransactionResponse {
     tx_id: string;
     tx_status: 'pending' | 'success' | 'abort_by_response' | 'abort_by_post_condition';


### PR DESCRIPTION
Transaction status polling was always hitting mainnet regardless of the configured network. Replaced the hardcoded URL with a resolver that reads from the shared network config, matching how the rest of the app handles network selection.

Closes #43