### PR TITLE
Require pending status before approve, reject, or confirm submission

### DIFF
--- a/contracts/bounty-vault.clar
+++ b/contracts/bounty-vault.clar
@@ -266,6 +266,8 @@
         )
         ;; Must be a registered arbiter in the dispute-resolver contract
         (asserts! (contract-call? .dispute-resolver is-registered-arbiter tx-sender) err-not-registered-arbiter)
+        ;; Submission must still be pending to confirm
+        (asserts! (is-eq (get status submission) "pending") err-not-pending)
         ;; Arbiter cannot be the project owner (prevents self-dealing)
         (asserts! (not (is-eq tx-sender (get project bounty))) err-unauthorized)
         ;; Arbiter cannot be the submitting researcher


### PR DESCRIPTION
approve-submission and reject-submission did not verify that the submission was still in pending status. This allowed double-approval (double payment) or re-rejection (double reputation penalty). Add an err-not-pending guard to both functions and extend it to confirm-approval for consistency.

Closes #45