### PR TITLE
Add missing rejected status to Dispute type

### DIFF
--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -36,6 +36,8 @@ export interface ResearcherProfile {
     isVerified: boolean;
 }
 
+export type DisputeStatus = 'open' | 'resolved' | 'rejected';
+
 export interface Dispute {
     id: number;
     submissionId: number;
@@ -44,7 +46,7 @@ export interface Dispute {
     createdAt: number;
     votesFor: number;
     votesAgainst: number;
-    status: 'open' | 'resolved' | 'rejected';
+    status: DisputeStatus;
     resolvedAt?: number;
 }
 


### PR DESCRIPTION
The dispute-resolver contract can resolve disputes as rejected when votes-against outnumber votes-for, but the Dispute TypeScript interface only declared open and resolved. Add the missing status and extract a reusable DisputeStatus type alias.

Closes #57