### PR TITLE
Validate cumulative milestone amounts in add-milestone

### DIFF
--- a/contracts/escrow.clar
+++ b/contracts/escrow.clar
@@ -276,6 +276,15 @@
     (map-get? milestones { escrow-id: escrow-id, milestone-index: milestone-index })
 )
 
+(define-read-only (get-remaining-committable (escrow-id uint))
+    (let
+        (
+            (escrow (unwrap! (map-get? escrows { escrow-id: escrow-id }) err-escrow-not-found))
+        )
+        (ok (- (get total-amount escrow) (get committed-amount escrow)))
+    )
+)
+
 (define-read-only (get-total-escrows)
     (ok (var-get escrow-nonce))
 )


### PR DESCRIPTION
add-milestone did not check whether the total value of all milestones exceeded the escrow's locked amount. Track committed-amount on the escrow, assert it stays within total-amount, and add a get-remaining-committable read-only function for frontend use.

Closes #46