### PR TITLE
Add dispute resolution path for escrow contracts

### DIFF
--- a/contracts/escrow.clar
+++ b/contracts/escrow.clar
@@ -352,3 +352,10 @@
 (define-read-only (get-total-escrows)
     (ok (var-get escrow-nonce))
 )
+
+(define-read-only (is-disputed (escrow-id uint))
+    (match (map-get? escrows { escrow-id: escrow-id })
+        escrow (ok (is-eq (get status escrow) "disputed"))
+        err-escrow-not-found
+    )
+)


### PR DESCRIPTION
A disputed escrow had no on-chain resolution path -- it was permanently frozen. Add resolve-escrow-dispute, callable by registered arbiters, which either returns the escrow to active or refunds the employer. Also add an is-disputed read-only helper.

Closes #48