### PR TITLE
Enforce grace period before bounty closure

### DIFF
--- a/contracts/bounty-vault.clar
+++ b/contracts/bounty-vault.clar
@@ -322,6 +322,12 @@
             { bounty-id: bounty-id }
             (merge bounty { is-active: false })
         )
+        (print {
+            event: "bounty-closed",
+            bounty-id: bounty-id,
+            refunded: remaining,
+            block-height: block-height
+        })
         (ok remaining)
     )
 )


### PR DESCRIPTION
close-bounty allowed immediate closure and fund reclaim while researchers might have pending submissions under review. Require that block-height exceeds the bounty expiry plus a 144-block grace period before the owner can close. Also emit a bounty-closed event for indexers.

Closes #50